### PR TITLE
Lexer error reporting

### DIFF
--- a/lib/mi.ex
+++ b/lib/mi.ex
@@ -26,7 +26,7 @@ defmodule Mi do
     #|> IO.inspect
 
     IO.inspect(@expression)
-    Lexer.lex("(#$)")
+    Lexer.lex(@expression)
     |> IO.inspect(limit: :infinity)
 
     # Lexer.lex("(')(')")

--- a/test/mi_lexer_test.exs
+++ b/test/mi_lexer_test.exs
@@ -67,20 +67,20 @@ defmodule MiLexerTest do
       (let add (lambda (a b) (+ a b)))
       """)
 
-      assert [%Token{line: 1, pos: 1}, %Token{line: 1, pos: 3},
-              %Token{line: 1, pos: 5}, %Token{line: 1, pos: 9},
+      assert [%Token{line: 1, pos: 1}, %Token{line: 1, pos: 2},
+              %Token{line: 1, pos: 3}, %Token{line: 1, pos: 7},
+              %Token{line: 1, pos: 9}, %Token{line: 1, pos: 10},
               %Token{line: 1, pos: 11}, %Token{line: 1, pos: 13},
-              %Token{line: 1, pos: 15}, %Token{line: 1, pos: 17},
-              %Token{line: 1, pos: 19}, %Token{line: 1, pos: 20},
-              %Token{line: 1, pos: 22}, %Token{line: 2, pos: 1},
-              %Token{line: 2, pos: 3}, %Token{line: 2, pos: 7},
-              %Token{line: 2, pos: 11}, %Token{line: 2, pos: 13},
-              %Token{line: 2, pos: 20}, %Token{line: 2, pos: 22},
+              %Token{line: 1, pos: 15}, %Token{line: 1, pos: 16},
+              %Token{line: 1, pos: 17}, %Token{line: 2, pos: 1},
+              %Token{line: 2, pos: 2}, %Token{line: 2, pos: 6},
+              %Token{line: 2, pos: 10}, %Token{line: 2, pos: 11},
+              %Token{line: 2, pos: 18}, %Token{line: 2, pos: 19},
+              %Token{line: 2, pos: 21}, %Token{line: 2, pos: 22},
               %Token{line: 2, pos: 24}, %Token{line: 2, pos: 25},
-              %Token{line: 2, pos: 28}, %Token{line: 2, pos: 30},
-              %Token{line: 2, pos: 33}, %Token{line: 2, pos: 35},
-              %Token{line: 2, pos: 36}, %Token{line: 2, pos: 38},
-              %Token{line: 2, pos: 40}] = result.tokens
+              %Token{line: 2, pos: 27}, %Token{line: 2, pos: 29},
+              %Token{line: 2, pos: 30}, %Token{line: 2, pos: 31},
+              %Token{line: 2, pos: 32}] = result.tokens
     end
   end
 end

--- a/test/mi_test.exs
+++ b/test/mi_test.exs
@@ -1,5 +1,5 @@
 defmodule MiTest do
   use ExUnit.Case
   doctest Mi
-  doctest Mi.Parser
+  doctest Mi.Lexer
 end


### PR DESCRIPTION
Working on error reporting, there are still 2 problems remaining with this setup:

- [x] Character position isn't accurate because we continue in `lex_symbol`, but we do error reporting in `lex`, when `rest` has already advanced a character. So, given the expression `($#)` it gives:
  ```elixir
  %Mi.Lexer{errors: ["1:3: unknown symbol 35", "1:5: unknown symbol 36"]}
  ```
- [x] As you can see in the example above, symbols are in their ASCII notation. I'm not sure how to get it to show right.

With this implementation we can also easily lex multi-character symbols like so:
```elixir
defp lex_symbol([?>, ?> | rest ]), do: {:ok, rest, {'>>', :brshift}} 
```
WDYT @muse 